### PR TITLE
Update constructor to use nullable type hinting

### DIFF
--- a/src/Snowplow/RefererParser/Parser.php
+++ b/src/Snowplow/RefererParser/Parser.php
@@ -14,7 +14,7 @@ class Parser
      */
     protected $internalHosts = [];
 
-    public function __construct(ConfigReaderInterface $configReader = null, array $internalHosts = [])
+    public function __construct(?ConfigReaderInterface $configReader = null, array $internalHosts = [])
     {
         $this->configReader = $configReader ?: static::createDefaultConfigReader();
         $this->internalHosts = $internalHosts;


### PR DESCRIPTION
Update constructor to use nullable type hinting and remove PHP deprecation warning message.