### PR TITLE
Handle potential null query in parse_str and removes PHP deprecation warning

### DIFF
--- a/src/Snowplow/RefererParser/Parser.php
+++ b/src/Snowplow/RefererParser/Parser.php
@@ -50,7 +50,7 @@ class Parser
 
         $searchTerm = null;
         if ($referer['parameters']) {
-            parse_str($refererParts['query'], $queryParts);
+            parse_str($refererParts['query']??'', $queryParts);
             foreach ($referer['parameters'] as $parameter) {
                 $searchTerm = isset($queryParts[$parameter]) ? $queryParts[$parameter] : $searchTerm;
             }


### PR DESCRIPTION
Handle PHP deprecation warning in parse_str(): Passing null to parameter #1 ($string) of type string is deprecated in /snowplow/referer-parser/php/src/Snowplow/RefererParser/Parser.php on line 53